### PR TITLE
[codex] Handle expired GitHub sessions in fetcher

### DIFF
--- a/e2e/tests/sync.spec.ts
+++ b/e2e/tests/sync.spec.ts
@@ -88,6 +88,27 @@ test.describe('Sync Functionality', () => {
     await expect(page.locator('#notification-count')).toContainText('3 notifications');
   });
 
+  test('session-expired sync response redirects to login refresh', async ({ page }) => {
+    await page.route('**/notifications/html/repo/test/repo', (route) => {
+      route.fulfill({
+        status: 401,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          detail: {
+            error: 'session_expired',
+            message: 'GitHub session has expired. Please re-authenticate.',
+          },
+        }),
+      });
+    });
+
+    await page.locator('#repo-input').fill('test/repo');
+    await page.locator('#sync-btn').click();
+
+    await expect(page.locator('#status-bar')).toContainText('Session expired');
+    await expect(page).toHaveURL(/\/app\/login\.html\?session_refresh=1/);
+  });
+
   test('sync stores notifications in IndexedDB', async ({ page }) => {
     await page.route('**/notifications/html/repo/test/repo', (route) => {
       route.fulfill({

--- a/ghinbox/api/fetcher.py
+++ b/ghinbox/api/fetcher.py
@@ -6,15 +6,39 @@ Fetches notifications HTML from GitHub using an authenticated browser session.
 
 import asyncio
 import html
+import json
+import os
+import re
+import threading
 import time
 import urllib.parse
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor
+from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 
 from playwright.sync_api import sync_playwright, BrowserContext
 
 from ghinbox.auth import create_authenticated_context
+
+
+DEFAULT_FETCH_LOG_DIR = "responses/github-fetcher"
+DEFAULT_FETCH_LOG_RETENTION_HOURS = 24
+FETCH_LOG_RETENTION_ENV = "GHINBOX_FETCH_LOG_RETENTION_HOURS"
+FETCH_DUMP_DIR_ENV = "GHINBOX_FETCH_DUMP_DIR"
+FETCH_DUMP_HTML_ENV = "GHINBOX_FETCH_DUMP_HTML"
+
+GITHUB_PAGE_READY_SELECTOR = (
+    ".notifications-list-item, "
+    ".blankslate, "
+    "body.logged-out, "
+    ".session-authentication, "
+    ".auth-form, "
+    'meta[name="route-pattern"][content*="/login"], '
+    'meta[name="user-login"][content=""]'
+)
 
 
 @dataclass
@@ -35,6 +59,71 @@ class ActionResult:
     status: str = "ok"
     error: str | None = None
     response_html: str | None = None
+
+
+def _safe_page_value(get_value: Callable[[], Any]) -> str | None:
+    """Return a page value if it is available without masking fetch failures."""
+    try:
+        value = get_value()
+    except Exception:
+        return None
+    return str(value) if value is not None else None
+
+
+def _safe_locator_count(page: Any, selector: str) -> int | None:
+    """Count diagnostic selectors without letting logging change fetch behavior."""
+    try:
+        return page.locator(selector).count()
+    except Exception:
+        return None
+
+
+def _is_github_login_url(url: str) -> bool:
+    """Return true when GitHub redirected the notifications request to login."""
+    parsed = urllib.parse.urlparse(url)
+    return parsed.netloc == "github.com" and parsed.path in {
+        "/login",
+        "/session",
+        "/sessions/two-factor",
+    }
+
+
+def _env_flag(name: str) -> bool:
+    value = os.environ.get(name, "")
+    return value.lower() in {"1", "true", "yes", "on"}
+
+
+def _fetch_log_retention_seconds() -> float | None:
+    raw_value = os.environ.get(FETCH_LOG_RETENTION_ENV)
+    if raw_value is None:
+        return DEFAULT_FETCH_LOG_RETENTION_HOURS * 60 * 60
+    try:
+        hours = float(raw_value)
+    except ValueError:
+        print(
+            f"[fetcher] Ignoring invalid {FETCH_LOG_RETENTION_ENV}={raw_value!r}; "
+            f"using {DEFAULT_FETCH_LOG_RETENTION_HOURS}h"
+        )
+        return DEFAULT_FETCH_LOG_RETENTION_HOURS * 60 * 60
+    if hours <= 0:
+        return None
+    return hours * 60 * 60
+
+
+def _prune_old_fetch_logs(dump_root: Path, *, now: datetime) -> None:
+    retention_seconds = _fetch_log_retention_seconds()
+    if retention_seconds is None:
+        return
+
+    cutoff = now.timestamp() - retention_seconds
+    for path in dump_root.iterdir():
+        if not path.is_file() or path.suffix not in {".html", ".json"}:
+            continue
+        try:
+            if path.stat().st_mtime < cutoff:
+                path.unlink()
+        except OSError as e:
+            print(f"[fetcher] Failed to prune old fetch log {path}: {e}")
 
 
 class NotificationsFetcher:
@@ -102,12 +191,6 @@ class NotificationsFetcher:
         Returns:
             FetchResult with HTML content and metadata
         """
-        if self._context is None:
-            self.start()
-
-        assert self._context is not None
-
-        # Build URL
         query = f"repo:{owner}/{repo}"
         url = f"https://github.com/notifications?query={urllib.parse.quote(query)}"
 
@@ -118,19 +201,59 @@ class NotificationsFetcher:
 
         timing: dict[str, int] = {}
         page = None
+        response_status: int | None = None
 
         try:
+            if self._context is None:
+                self.start()
+
+            assert self._context is not None
+
             t0 = time.perf_counter()
             page = self._context.new_page()
             timing["new_page_ms"] = int((time.perf_counter() - t0) * 1000)
 
             t0 = time.perf_counter()
-            page.goto(url, wait_until="domcontentloaded")
+            response = page.goto(url, wait_until="domcontentloaded")
+            response_status = response.status if response is not None else None
             timing["goto_ms"] = int((time.perf_counter() - t0) * 1000)
 
-            # Wait for either notifications or empty state to be in DOM
+            if _is_github_login_url(page.url):
+                t0 = time.perf_counter()
+                html = page.content()
+                timing["content_ms"] = int((time.perf_counter() - t0) * 1000)
+
+                error_text = (
+                    "GitHub redirected notifications request to login. "
+                    "Stored browser session is expired."
+                )
+                self._log_github_page(
+                    page=page,
+                    requested_url=url,
+                    html=html,
+                    timing=timing,
+                    response_status=response_status,
+                    event="github_notifications_session_expired",
+                    error=error_text,
+                )
+
+                t0 = time.perf_counter()
+                page.close()
+                timing["close_ms"] = int((time.perf_counter() - t0) * 1000)
+
+                return FetchResult(
+                    html=html,
+                    url=url,
+                    status="session_expired",
+                    error=error_text,
+                    timing=timing,
+                )
+
+            # Wait for either notifications, an empty state, or a GitHub
+            # logged-out/login page to be in DOM. The parser turns logged-out
+            # HTML into a session_expired API response.
             t0 = time.perf_counter()
-            page.locator(".notifications-list-item, .blankslate").first.wait_for(
+            page.locator(GITHUB_PAGE_READY_SELECTOR).first.wait_for(
                 state="attached",
                 timeout=10000,
             )
@@ -139,6 +262,15 @@ class NotificationsFetcher:
             t0 = time.perf_counter()
             html = page.content()
             timing["content_ms"] = int((time.perf_counter() - t0) * 1000)
+
+            self._log_github_page(
+                page=page,
+                requested_url=url,
+                html=html,
+                timing=timing,
+                response_status=response_status,
+                event="github_notifications_fetch",
+            )
 
             t0 = time.perf_counter()
             page.close()
@@ -154,6 +286,19 @@ class NotificationsFetcher:
                 print(f"[fetcher] Timing: {timing}")
             if page is not None:
                 try:
+                    page_html = page.content()
+                    self._log_github_page(
+                        page=page,
+                        requested_url=url,
+                        html=page_html,
+                        timing=timing,
+                        response_status=response_status,
+                        event="github_notifications_fetch_error",
+                        error=error_text,
+                    )
+                except Exception as dump_error:
+                    print(f"[fetcher] Failed to dump page: {dump_error}")
+                try:
                     page.close()
                 except Exception as close_error:
                     print(f"[fetcher] Failed to close page: {close_error}")
@@ -164,6 +309,97 @@ class NotificationsFetcher:
                 error=error_text,
                 timing=timing,
             )
+
+    def _log_github_page(
+        self,
+        *,
+        page: Any,
+        requested_url: str,
+        html: str,
+        timing: dict[str, int],
+        response_status: int | None,
+        event: str,
+        error: str | None = None,
+    ) -> None:
+        now = datetime.now(timezone.utc)
+        final_url = _safe_page_value(lambda: page.url)
+        title = _safe_page_value(page.title)
+        selector_counts = {
+            "notifications": _safe_locator_count(page, ".notifications-list-item"),
+            "blankslate": _safe_locator_count(page, ".blankslate"),
+            "logged_out_body": _safe_locator_count(page, "body.logged-out"),
+            "session_authentication": _safe_locator_count(
+                page, ".session-authentication"
+            ),
+            "auth_form": _safe_locator_count(page, ".auth-form"),
+            "login_route_meta": _safe_locator_count(
+                page, 'meta[name="route-pattern"][content*="/login"]'
+            ),
+            "empty_user_login_meta": _safe_locator_count(
+                page, 'meta[name="user-login"][content=""]'
+            ),
+        }
+        metadata = {
+            "event": event,
+            "timestamp": now.isoformat(),
+            "account": self.account,
+            "requested_url": requested_url,
+            "final_url": final_url,
+            "title": title,
+            "response_status": response_status,
+            "error": error,
+            "timing": timing,
+            "selector_counts": selector_counts,
+            "html_path": None,
+            "metadata_path": None,
+            "html_bytes": len(html.encode("utf-8")),
+        }
+
+        try:
+            self._write_fetch_log_files(
+                metadata=metadata,
+                html=html,
+                requested_url=requested_url,
+                now=now,
+            )
+        except Exception as e:
+            metadata["log_error"] = f"{type(e).__name__}: {e}"
+
+        print(f"[fetcher] {json.dumps(metadata, sort_keys=True)}")
+
+    def _write_fetch_log_files(
+        self,
+        *,
+        metadata: dict[str, Any],
+        html: str,
+        requested_url: str,
+        now: datetime,
+    ) -> None:
+        """Write bounded fetch diagnostics without making logging part of fetch success."""
+        dump_root = Path(os.environ.get(FETCH_DUMP_DIR_ENV, DEFAULT_FETCH_LOG_DIR))
+        dump_root.mkdir(parents=True, exist_ok=True)
+        _prune_old_fetch_logs(dump_root, now=now)
+
+        parsed = urllib.parse.urlparse(requested_url)
+        query = urllib.parse.parse_qs(parsed.query).get("query", ["notifications"])[0]
+        slug = re.sub(r"[^A-Za-z0-9_.-]+", "_", query).strip("_") or "notifications"
+        timestamp = now.strftime("%Y%m%dT%H%M%S.%fZ")
+        stem = f"{timestamp}_{slug}"
+
+        if (
+            _env_flag(FETCH_DUMP_HTML_ENV)
+            or metadata["event"] != "github_notifications_fetch"
+        ):
+            html_path = dump_root / f"{stem}.html"
+            html_path.write_text(html, encoding="utf-8")
+            metadata["html_path"] = str(html_path)
+
+        metadata_path = dump_root / f"{stem}.json"
+        metadata["metadata_path"] = str(metadata_path)
+        metadata_path.write_text(
+            json.dumps(metadata, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
 
     def submit_notification_action(
         self,
@@ -285,17 +521,33 @@ class NotificationsFetcher:
         self.stop()
 
 
-# Single-thread executor to keep Playwright sync API on one thread.
-_fetch_executor = ThreadPoolExecutor(max_workers=1)
+_fetch_executor: ThreadPoolExecutor | None = None
+_fetch_worker_lock = threading.Lock()
+
+
+def _submit_fetcher_call(func: Callable[[], Any]) -> Future[Any]:
+    global _fetch_executor
+    with _fetch_worker_lock:
+        if _fetch_executor is None:
+            _fetch_executor = ThreadPoolExecutor(
+                max_workers=1,
+                thread_name_prefix="ghinbox-playwright-fetcher",
+            )
+        return _fetch_executor.submit(func)
 
 
 async def run_fetcher_call(func, *args, **kwargs):
-    loop = asyncio.get_running_loop()
-    return await loop.run_in_executor(_fetch_executor, lambda: func(*args, **kwargs))
+    future = _submit_fetcher_call(lambda: func(*args, **kwargs))
+    return await asyncio.wrap_future(future)
 
 
 def shutdown_fetcher_executor() -> None:
-    _fetch_executor.shutdown(wait=False)
+    global _fetch_executor
+    with _fetch_worker_lock:
+        executor = _fetch_executor
+        _fetch_executor = None
+    if executor is not None:
+        executor.shutdown(wait=True)
 
 
 # Global fetcher instance (set by server on startup)

--- a/ghinbox/api/routes.py
+++ b/ghinbox/api/routes.py
@@ -101,6 +101,15 @@ async def get_repo_notifications(
             before=before,
             after=after,
         )
+        if result.status == "session_expired":
+            raise HTTPException(
+                status_code=401,
+                detail={
+                    "error": "session_expired",
+                    "message": result.error
+                    or "GitHub session has expired. Please re-authenticate.",
+                },
+            )
         if result.status == "error":
             print(f"[notifications] Fetch error for {owner}/{repo}: {result.error}")
             raise HTTPException(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,6 +8,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from ghinbox.api.app import app
+from ghinbox.api.fetcher import FetchResult
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
@@ -159,6 +160,35 @@ class TestGetRepoNotifications:
         data = response.json()
 
         assert "after=cursor123" in data["source_url"]
+
+    def test_live_fetch_session_expired_returns_401(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test live fetch login redirects surface as session_expired."""
+
+        class FakeFetcher:
+            def fetch_repo_notifications(
+                self,
+                owner: str,
+                repo: str,
+                before: str | None = None,
+                after: str | None = None,
+            ) -> FetchResult:
+                return FetchResult(
+                    html="<html><title>Unicorn! - GitHub</title></html>",
+                    url=f"https://github.com/notifications?query=repo:{owner}/{repo}",
+                    status="session_expired",
+                    error="GitHub redirected notifications request to login.",
+                )
+
+        monkeypatch.setattr("ghinbox.api.routes.get_fetcher", lambda: FakeFetcher())
+
+        response = client.get("/notifications/html/repo/testowner/testrepo")
+
+        assert response.status_code == 401
+        detail = response.json()["detail"]
+        assert detail["error"] == "session_expired"
+        assert "redirected" in detail["message"]
 
 
 class TestParseEndpoint:

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -1,0 +1,231 @@
+import asyncio
+import json
+import os
+import threading
+import time
+from pathlib import Path
+from typing import Any, cast
+
+from ghinbox.api.fetcher import (
+    NotificationsFetcher,
+    run_fetcher_call,
+    shutdown_fetcher_executor,
+)
+
+
+class FakeLocator:
+    def __init__(self, selector: str, page: "FakePage") -> None:
+        self.selector = selector
+        self.page = page
+        self.first = self
+
+    def wait_for(self, *, state: str, timeout: int) -> None:
+        self.page.wait_selector = self.selector
+        assert state == "attached"
+        assert timeout == 10000
+        if "body.logged-out" not in self.selector:
+            raise TimeoutError("login marker was not included in ready selector")
+
+    def count(self) -> int:
+        return self.page.counts.get(self.selector, 0)
+
+
+class FakeResponse:
+    status = 200
+
+
+class FakePage:
+    def __init__(
+        self,
+        *,
+        url: str = "https://github.com/login?return_to=%2Fnotifications",
+    ) -> None:
+        self.url = url
+        self.wait_selector: str | None = None
+        self.closed = False
+        self.counts = {
+            ".notifications-list-item": 0,
+            ".blankslate": 0,
+            "body.logged-out": 1,
+            ".session-authentication": 1,
+            ".auth-form": 1,
+            'meta[name="route-pattern"][content*="/login"]': 1,
+            'meta[name="user-login"][content=""]': 1,
+        }
+
+    def goto(self, url: str, *, wait_until: str) -> FakeResponse:
+        assert url == "https://github.com/notifications?query=repo%3Atestowner/testrepo"
+        assert wait_until == "domcontentloaded"
+        return FakeResponse()
+
+    def locator(self, selector: str) -> FakeLocator:
+        return FakeLocator(selector, self)
+
+    def content(self) -> str:
+        if (
+            self.url
+            == "https://github.com/notifications?query=repo%3Atestowner/testrepo"
+        ):
+            return """
+            <html>
+              <head>
+                <meta name="route-pattern" content="/notifications(.:format)">
+                <meta name="user-login" content="ezyang0">
+              </head>
+              <body>
+                <div class="notifications-list-item">Notification</div>
+              </body>
+            </html>
+            """
+        return """
+        <html>
+          <head>
+            <meta name="route-pattern" content="/login">
+            <meta name="user-login" content="">
+          </head>
+          <body class="logged-out">
+            <div class="session-authentication">Sign in</div>
+          </body>
+        </html>
+        """
+
+    def title(self) -> str:
+        return "GitHub"
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class FakeContext:
+    def __init__(
+        self,
+        *,
+        page_url: str = "https://github.com/login?return_to=%2Fnotifications",
+    ) -> None:
+        self.page = FakePage(url=page_url)
+
+    def new_page(self) -> FakePage:
+        return self.page
+
+
+def test_fetch_returns_session_expired_for_login_redirect(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setenv("GHINBOX_FETCH_DUMP_DIR", str(tmp_path))
+    fetcher = NotificationsFetcher(account="default")
+    context = FakeContext()
+    cast(Any, fetcher)._context = context
+
+    result = fetcher.fetch_repo_notifications("testowner", "testrepo")
+
+    assert result.status == "session_expired"
+    assert result.error is not None
+    assert "redirected" in result.error
+    assert 'body class="logged-out"' in result.html
+    assert context.page.wait_selector is None
+    assert context.page.closed is True
+
+    html_dumps = list(tmp_path.glob("*.html"))
+    metadata_dumps = list(tmp_path.glob("*.json"))
+    assert len(html_dumps) == 1
+    assert len(metadata_dumps) == 1
+    assert "Sign in" in html_dumps[0].read_text()
+    metadata = json.loads(metadata_dumps[0].read_text())
+    assert metadata["event"] == "github_notifications_session_expired"
+    assert metadata["selector_counts"]["logged_out_body"] == 1
+
+
+def test_success_fetch_writes_metadata_without_html_dump_by_default(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setenv("GHINBOX_FETCH_DUMP_DIR", str(tmp_path))
+    monkeypatch.delenv("GHINBOX_FETCH_DUMP_HTML", raising=False)
+    fetcher = NotificationsFetcher(account="default")
+    context = FakeContext(
+        page_url="https://github.com/notifications?query=repo%3Atestowner/testrepo"
+    )
+    cast(Any, fetcher)._context = context
+
+    result = fetcher.fetch_repo_notifications("testowner", "testrepo")
+
+    assert result.status == "ok"
+    assert context.page.closed is True
+    assert list(tmp_path.glob("*.html")) == []
+    metadata_dumps = list(tmp_path.glob("*.json"))
+    assert len(metadata_dumps) == 1
+    metadata = json.loads(metadata_dumps[0].read_text())
+    assert metadata["event"] == "github_notifications_fetch"
+    assert metadata["html_path"] is None
+    assert metadata["metadata_path"] == str(metadata_dumps[0])
+
+
+def test_fetch_logging_is_best_effort(monkeypatch: Any) -> None:
+    fetcher = NotificationsFetcher(account="default")
+    context = FakeContext(
+        page_url="https://github.com/notifications?query=repo%3Atestowner/testrepo"
+    )
+    cast(Any, fetcher)._context = context
+
+    def fail_write(**kwargs: Any) -> None:
+        raise OSError("disk is full")
+
+    monkeypatch.setattr(fetcher, "_write_fetch_log_files", fail_write)
+
+    result = fetcher.fetch_repo_notifications("testowner", "testrepo")
+
+    assert result.status == "ok"
+    assert result.error is None
+
+
+def test_fetch_logs_prune_old_files(tmp_path: Path, monkeypatch: Any) -> None:
+    monkeypatch.setenv("GHINBOX_FETCH_DUMP_DIR", str(tmp_path))
+    monkeypatch.setenv("GHINBOX_FETCH_LOG_RETENTION_HOURS", "1")
+    old_log = tmp_path / "old.json"
+    fresh_log = tmp_path / "fresh.json"
+    old_log.write_text("{}")
+    fresh_log.write_text("{}")
+    old_time = time.time() - (2 * 60 * 60)
+    os.utime(old_log, (old_time, old_time))
+
+    fetcher = NotificationsFetcher(account="default")
+    context = FakeContext(
+        page_url="https://github.com/notifications?query=repo%3Atestowner/testrepo"
+    )
+    cast(Any, fetcher)._context = context
+
+    result = fetcher.fetch_repo_notifications("testowner", "testrepo")
+
+    assert result.status == "ok"
+    assert not old_log.exists()
+    assert fresh_log.exists()
+
+
+def test_run_fetcher_call_serializes_work_on_one_worker_thread() -> None:
+    seen_threads: set[int] = set()
+    order: list[int] = []
+
+    async def run() -> list[int]:
+        await asyncio.gather(
+            run_fetcher_call(record_task, 1),
+            run_fetcher_call(record_task, 2),
+        )
+        return order
+
+    def record_task(value: int) -> None:
+        try:
+            asyncio.get_running_loop()
+            raise AssertionError("fetcher worker should not have a running event loop")
+        except RuntimeError:
+            pass
+        seen_threads.add(threading.get_ident())
+        order.append(value)
+
+    try:
+        result = asyncio.run(run())
+    finally:
+        shutdown_fetcher_executor()
+
+    assert result == [1, 2]
+    assert len(seen_threads) == 1


### PR DESCRIPTION
## Summary

- Detect expired GitHub session responses in the fetcher and surface them as a structured error state.
- Thread session-expired handling through API routes.
- Add Python and E2E coverage for the expired-session flow.

## Validation

- Not run in this publish-only step; this PR publishes the existing local commit `8c52e2c`.